### PR TITLE
Feature multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Specify the path to `coverage.json` file relative to your current working direct
 let g:coverage_json_report_path = 'coverage/coverage.json'
 ```
 
+Or if you have multiple files (from backend and frontend for example).
+
+Entries are summed up (but conflicts can emerge if the same files are analyzed)
+
+```
+let g:coverage_json_report_pathes = ['coverage/coverage-final.json', 'coverage/Firefox YZ/coverage-final.json']
+```
+
 Define the symbol display for covered lines
 
 ```
@@ -53,6 +61,11 @@ Display signs on uncovered lines
 
 ```
 let g:coverage_show_uncovered = 1
+```
+
+To set the base path from which coverage\_json\_report\_path[es] are resolved
+```
+let g:coverage_json_project_path = '/my/absolute/path'
 ```
 
 > If you found the project helpful, please give it a star :)

--- a/autoload/coverage.vim
+++ b/autoload/coverage.vim
@@ -32,7 +32,7 @@ function! coverage#get_coverage_lines(file_name) abort
 
   for path in coverage_json_full_pathes
     if !filereadable(path)
-      echoerr '"' . path . '" is not found'
+      " echoerr '"' . path . '" is not found'
       continue
     endif
 


### PR DESCRIPTION
Hello,

I did a small edit of your plugin to allow multiple input files for coverage.
To keep backwards compatibility I added ```g:coverage_json_report_pathes``` which is a list of files
I also added the documentation to the README.md.

The relative pathes were incovenient for me so I added ```g:coverage_json_project_path``` which allow to specify the project directory instead of the working directory.

I hope it will be as useful for you as it's for me.

Best Regards,
Louis